### PR TITLE
39278 : Fix Welcome Widget Width in Snapshot page

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/skin/less/digital-workplace.less
+++ b/digital-workplace-webapps/src/main/webapp/skin/less/digital-workplace.less
@@ -36,6 +36,8 @@
     #UserProfileContainerChildren {
       display: flex;
       flex-direction: column;
+      width: 370px;
+      max-width: 100%;
 
       > :first-child {
         flex-basis: auto;


### PR DESCRIPTION
Welcome Widget in SNAPSHOT page is reduced when adding pinned articles with big images.
This fix will define the width of right column in SNAPSHOT page to ensure that it's not reduced.