### PR TITLE
TASK-39278 Fix Welcome Widget Width in Snapshot page

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/skin/less/digital-workplace.less
+++ b/digital-workplace-webapps/src/main/webapp/skin/less/digital-workplace.less
@@ -40,6 +40,7 @@
       max-width: 100%;
       margin-left: auto ~'; /** orientation=lt */ ';
       margin-right: auto ~'; /** orientation=rt */ ';
+      width: 370px;
 
       > :first-child {
         flex-basis: auto;

--- a/digital-workplace-webapps/src/main/webapp/skin/less/digital-workplace.less
+++ b/digital-workplace-webapps/src/main/webapp/skin/less/digital-workplace.less
@@ -40,7 +40,6 @@
       max-width: 100%;
       margin-left: auto ~'; /** orientation=lt */ ';
       margin-right: auto ~'; /** orientation=rt */ ';
-      width: 370px;
 
       > :first-child {
         flex-basis: auto;
@@ -154,6 +153,7 @@
 @media (min-width: @minDesktop) {
   #digitalWorkplaceHomePage {
     #UserProfileContainerChildren {
+      min-width: 370px;
       #ProfileStatsContainer:only-child {
         #profile-stats-portlet .profileCard {
           min-height: 404px;


### PR DESCRIPTION
Welcome Widget in SNAPSHOT page is reduced when adding pinned articles with big images.
This fix will define the width of right column in SNAPSHOT page to ensure that it's not reduced.