### PR TITLE
MAINT-49262: Fix the display of the recent documents tab container after the migration from 6.1.5 to 6.2.0

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-configuration.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-configuration.xml
@@ -29,7 +29,7 @@
               <boolean>true</boolean>
             </field>
             <field name="importMode">
-              <string>${exo.dw.portalConfig.metadata.importmode:insert}</string>
+              <string>${exo.dw.portalConfig.metadata.importmode:merge}</string>
             </field>
             <field name="predefinedOwner">
               <collection type="java.util.HashSet">


### PR DESCRIPTION
**ISSUE**: The insertMode in the portal config of the **dw** site in the digital-workplace was set to insert which prevents the update of the containers of the homepage and replace the old `UITabContainer` by the new `UIDocumentTabContainer` in pages config.
**FIX**: change the insert mode to merge