### PR TITLE
Revert "MAINT-49262: Fix the display of the recent documents tab container after the migration from 6.1.5 to 6.2.0"

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-configuration.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-configuration.xml
@@ -29,7 +29,7 @@
               <boolean>true</boolean>
             </field>
             <field name="importMode">
-              <string>${exo.dw.portalConfig.metadata.importmode:merge}</string>
+              <string>${exo.dw.portalConfig.metadata.importmode:insert}</string>
             </field>
             <field name="predefinedOwner">
               <collection type="java.util.HashSet">


### PR DESCRIPTION
Reverts exoplatform/digital-workplace#34