### PR TITLE
Task-54647: Bad display for slider news

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/skin/less/digital-workplace.less
+++ b/digital-workplace-webapps/src/main/webapp/skin/less/digital-workplace.less
@@ -15,10 +15,8 @@
       max-width: 100%;
     }
   }
-  
+
   #MiddleContainer {
-    margin-top: 20px;
-    margin-bottom: 20px;
 
     #MiddleContainerChildren {
       display: flex;


### PR DESCRIPTION
Problem: When you add the slider news on another page(not snapshot page) there’s a bad display : no padding and the height is not fixed.
Fix: I fixed the display of slider news, so I removed the margin top and bottom of MiddleContainer in the digital-workplace module.