### PR TITLE
Task-57077: Adjust LatestNewsContainer and BottomContainer UI display

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/skin/less/digital-workplace.less
+++ b/digital-workplace-webapps/src/main/webapp/skin/less/digital-workplace.less
@@ -24,6 +24,7 @@
       > :first-child {
         flex-basis: auto;
         flex-grow: 1;
+        max-width: ~"calc( 100% - 390px )";
       }
 
       > :nth-child(2) {
@@ -177,10 +178,15 @@
 
       #MiddleContainerChildren {
         flex-direction: column;
+
+        > :first-child {
+          max-width: 100%;
+        }
   
         > :nth-child(2) {
           margin-left: 0 !important;
           margin-right: 0 !important;
+          max-height: none;
         }
       }
     }
@@ -229,14 +235,17 @@
       }
     }
 
-    #BottomContainer #BottomContainerChildren {
-      flex-wrap: wrap;
-
-      > :nth-child(3) {
-        margin-left: 0 !important;
-        margin-right: 0 !important;
-        min-width: 100%;
-        margin-top: 20px;
+    #BottomContainer {
+      margin-top: 10px;
+      #BottomContainerChildren {
+        flex-wrap: wrap;
+  
+        > :nth-child(3) {
+          margin-left: 0 !important;
+          margin-right: 0 !important;
+          min-width: 100%;
+          margin-top: 20px;
+        }
       }
     }
 


### PR DESCRIPTION
Prior to this fix, when using some types of news list templates, a bad display of the `LatestNewsContainer` occurs and tooks a large width in addition of a bad display of the `BottomContainer` in responsive mode.
After this fix, we will be able to choose any type of news list templates without any display issues. 