### PR TITLE
fix: Move eXoResources and eXoSkin Maven Modules from meeds to eXo - Meeds-io/MIPs#52

### DIFF
--- a/digital-workplace-packaging/pom.xml
+++ b/digital-workplace-packaging/pom.xml
@@ -30,14 +30,14 @@
 			<type>war</type>
 		</dependency>
     <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.web.eXoResources</artifactId>
+      <groupId>org.exoplatform.commons-exo</groupId>
+      <artifactId>commons-exo.portal.web.eXoResources</artifactId>
 			<type>war</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.web.eXoSkin</artifactId>
+      <groupId>org.exoplatform.commons-exo</groupId>
+      <artifactId>commons-exo.portal.web.eXoSkin</artifactId>
 			<type>war</type>
       <scope>provided</scope>
     </dependency>

--- a/digital-workplace-packaging/src/main/assemblies/packaging.xml
+++ b/digital-workplace-packaging/src/main/assemblies/packaging.xml
@@ -42,7 +42,7 @@
       <useProjectArtifact>false</useProjectArtifact>
       <outputDirectory>/webapps</outputDirectory>
       <includes>
-        <include>org.exoplatform.gatein.portal:exo.portal.web.eXoResources:war</include>
+        <include>org.exoplatform.commons-exo:commons-exo.portal.web.eXoResources:war</include>
       </includes>
       <scope>provided</scope>
       <outputFileNameMapping>eXoResources.war</outputFileNameMapping>
@@ -51,7 +51,7 @@
       <useProjectArtifact>false</useProjectArtifact>
       <outputDirectory>/webapps</outputDirectory>
       <includes>
-        <include>org.exoplatform.gatein.portal:exo.portal.web.eXoSkin:war</include>
+        <include>org.exoplatform.commons-exo:commons-exo.portal.web.eXoSkin:war</include>
       </includes>
       <scope>provided</scope>
       <outputFileNameMapping>eXoSkin.war</outputFileNameMapping>


### PR DESCRIPTION
This change will move eXoResources.war and eXoSkin.war resources from gatein-portal to commons-exo