### PR TITLE
feat : Portlet UI Cleanup - Merge meeds-io/MIPs#81

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/branding-configuration.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/branding-configuration.xml
@@ -70,6 +70,7 @@
         <value>${exo.branding.theme.tertiaryColor:tertiaryColor:#476A9C}</value>
         <value>${exo.branding.theme.greyColorLighten1:greyColorLighten1:#5f708a}</value>
         <value>${exo.branding.theme.textColor:textColor:#333333}</value>
+        <value>${exo.branding.theme.borderRadius:borderRadius:8px}</value>
       </values-param>
     </init-params>
   </component>


### PR DESCRIPTION
Before this fix, the new branding settings (radius) cannot be saved in interface This is due to the override of the BrandingService configuration file Then the new property about radius was not added on our side. This commit add the property