### PR TITLE
fix: Define profiles for eXo administration site pages - EXO-67778 (#98)

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/administration/pages.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/administration/pages.xml
@@ -39,7 +39,7 @@
     </container>
   </page>
   
-  <page>
+  <page profiles="layout-management">
     <name>siteManagement</name>
     <title>Site Management</title>
     <access-permissions>manager:/platform/administrators</access-permissions>
@@ -58,7 +58,7 @@
     </container>
   </page>
   
-  <page>
+  <page profiles="agenda">
     <name>agendaAdminSettings</name>
     <title>Agenda admin settings</title>
     <access-permissions>*:/platform/administrators</access-permissions>
@@ -77,7 +77,7 @@
     </container>
   </page>
   
-  <page>
+  <page profiles="webconferencing">
     <name>webconferencing</name>
     <title>Web Conferencing Administration</title>
     <access-permissions>*:/platform/administrators</access-permissions>
@@ -96,7 +96,7 @@
     </container>
   </page>
   
-  <page>
+  <page profiles="automatic-translation">
     <name>automatic-translation</name>
     <title>Automatic Translation</title>
     <access-permissions>*:/platform/administrators</access-permissions>
@@ -213,7 +213,7 @@
     </container>
   </page>
   
-  <page>
+  <page profiles="ecms">
     <name>cloudStorage</name>
     <title>Cloud Storage</title>
     <access-permissions>*:/platform/administrators</access-permissions>
@@ -232,7 +232,7 @@
     </container>
   </page>
   
-  <page>
+  <page profiles="ecms">
     <name>editors</name>
     <title>Editors Administration</title>
     <access-permissions>*:/platform/administrators</access-permissions>
@@ -251,7 +251,7 @@
     </container>
   </page>
   
-  <page>
+  <page profiles="news">
     <name>newsTargets</name>
     <title>News targets</title>
     <access-permissions>manager:/platform/web-contributors</access-permissions>
@@ -272,7 +272,7 @@
     </container>
   </page>
   
-  <page>
+  <page profiles="dlp">
     <name>dlp-quarantine</name>
     <title>Dlp Quarantine</title>
     <access-permissions>*:/platform/dlp</access-permissions>
@@ -292,7 +292,7 @@
     </container>
   </page>
   
-  <page>
+  <page profiles="ecms">
     <name>transferRules</name>
     <title>Transfer Rules</title>
     <access-permissions>*:/platform/administrators</access-permissions>
@@ -310,7 +310,7 @@
     </container>
   </page>
   
-  <page>
+  <page profiles="multifactor-authentication">
     <name>multifactor-authentication</name>
     <title>Multifactor authentication</title>
     <access-permissions>*:/platform/administrators</access-permissions>
@@ -330,7 +330,7 @@
     </container>
   </page>
   
-  <page>
+  <page profiles="ecms">
     <name>SiteExplorer</name>
     <title>Site Explorer</title>
     <access-permissions>*:/platform/web-contributors</access-permissions>
@@ -369,7 +369,7 @@
     </container>
   </page>
   
-  <page>
+  <page profiles="ecms">
     <name>WcmAdmin</name>
     <title>WCM Administration</title>
     <access-permissions>manager:/platform/web-contributors</access-permissions>


### PR DESCRIPTION
After this change, we will define profiles for eXo administration site pages in order to be created only when the corresponding addon is installed.