### PR TITLE
fix: Fix public site creation - EXO-69425 (#115)

### DIFF
--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_en.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_en.properties
@@ -1,0 +1,2 @@
+portal.public.newsDetail=News details
+portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-configuration.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-configuration.xml
@@ -110,6 +110,38 @@
       <name>new.portal.config.user.listener</name>
       <set-method>initListener</set-method>
       <type>org.exoplatform.portal.config.NewPortalConfigListener</type>
+      <priority>900</priority>
+      <init-params>
+        <object-param>
+          <name>portal.configuration</name>
+          <object type="org.exoplatform.portal.config.NewPortalConfig">
+            <field name="predefinedOwner">
+              <collection type="java.util.HashSet">
+                <value>
+                  <string>public</string>
+                </value>
+              </collection>
+            </field>
+            <field name="ownerType">
+              <string>portal</string>
+            </field>
+            <field name="templateLocation">
+              <string>war:/conf/digital-workplace</string>
+            </field>
+            <field name="override">
+              <boolean>${io.meeds.public.portalConfig.metadata.override:true}</boolean>
+            </field>
+            <field name="importMode">
+              <string>${io.meeds.public.portalConfig.metadata.importmode:insert}</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>new.portal.config.user.listener</name>
+      <set-method>initListener</set-method>
+      <type>org.exoplatform.portal.config.NewPortalConfigListener</type>
       <init-params>
         <object-param>
           <name>portal.configuration</name>

--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/public/navigation.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/public/navigation.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright (C) 2024 eXo Platform SAS.
+
+ This is free software; you can redistribute it and/or modify it
+ under the terms of the GNU Lesser General Public License as
+ published by the Free Software Foundation; either version 2.1 of
+ the License, or (at your option) any later version.
+
+ This software is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this software; if not, write to the Free
+ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+
+<node-navigation
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_11 http://www.gatein.org/xml/ns/gatein_objects_1_11"
+  xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_11">
+  <priority>3</priority>
+  <page-nodes>
+    <node>
+      <name>news-detail</name>
+      <label>#{portal.public.newsDetail}</label>
+      <visibility>SYSTEM</visibility>
+      <page-reference>portal::public::newsDetail</page-reference>
+    </node>
+    <node>
+      <name>oeditor</name>
+      <label>#{portal.public.oeditor}</label>
+      <visibility>SYSTEM</visibility>
+      <page-reference>portal::public::oeditor</page-reference>
+    </node>
+  </page-nodes>
+</node-navigation>

--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/public/pages.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/public/pages.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright (C) 2024 eXo Platform SAS.
+
+ This is free software; you can redistribute it and/or modify it
+ under the terms of the GNU Lesser General Public License as
+ published by the Free Software Foundation; either version 2.1 of
+ the License, or (at your option) any later version.
+
+ This software is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this software; if not, write to the Free
+ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+<page-set
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_11 http://www.gatein.org/xml/ns/gatein_objects_1_11"
+  xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_11">
+  <page profiles="news">
+    <name>newsDetail</name>
+    <title>News detail</title>
+    <access-permissions>Everyone</access-permissions>
+    <edit-permission>*:/platform/administrators</edit-permission>
+    <container id="NewsDetailContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>news</application-ref>
+          <portlet-ref>NewsDetail</portlet-ref>
+        </portlet>
+        <title>News Detail</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+        <show-application-state>false</show-application-state>
+        <show-application-mode>false</show-application-mode>
+      </portlet-application>
+    </container>
+  </page>
+  <page profiles="onlyoffice">
+    <name>oeditor</name>
+    <title>Onlyoffice Editor Page</title>
+    <access-permissions>Everyone</access-permissions>
+    <edit-permission>manager:/platform/administrators</edit-permission>
+    <container id="OnlyofficeEditorPage" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>onlyoffice</application-ref>
+          <portlet-ref>OnlyofficeEditorPortlet</portlet-ref>
+        </portlet>
+        <title>Onlyoffice Editor</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+        <show-application-state>true</show-application-state>
+      </portlet-application>
+    </container>
+  </page>
+</page-set>

--- a/translations.properties
+++ b/translations.properties
@@ -25,6 +25,7 @@ DW.properties=digital-workplace-webapps/src/main/resources/locale/navigation/por
 Intranet.properties=digital-workplace-webapps/src/main/resources/locale/navigation/portal/intranet_en.properties
 MyCraft.properties=digital-workplace-webapps/src/main/resources/locale/navigation/portal/mycraft_en.properties
 Administration.properties=digital-workplace-webapps/src/main/resources/locale/navigation/portal/administration_en.properties
+Public.properties=digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_en.properties
 
 Webui.properties=digital-workplace-webapps/src/main/resources/locale/portal/webui_en.properties
 # Login


### PR DESCRIPTION
Prior to this change, the public site is not well created when migrating from 6.4.4 to latest 6.5.1 or 6.6.x, this is due to the NewPortalConfigListener configuration defined in "News" and "Onlyoffce" addons on "public" site which can be executed before the basic "public" site configuration defined into sites module of "Meeds" project. To fix this problem, we need to centralize the configuration into "Digital-workplace" addon with a higher priority regarding the basic "public" site configuration in order to be executed at the last.