### PR TITLE
feat: Move News and OnlyOffice details pages to global site - MEED-6224 - Meeds-io/MIPs#120

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -88,7 +88,7 @@ files: [
     "escape_quotes" : 0,
   },
   {
-    "source" : "/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_en.properties",
+    "source" : "/digital-workplace-webapps/src/main/resources/locale/navigation/portal/global_en.properties",
 
     "translation" : "%original_path%/%file_name%!_%locale_with_underscore%.%file_extension%",
     "translation_replace" : {
@@ -100,7 +100,7 @@ files: [
       "sv_SE": "sv_SE","th_TH": "th","tl_PH": "tl","tr_TR": "tr","uk_UA": "uk","ur_IN": "ur_IN","vi_VN": "vi",
       "zh_CN": "zh_CN","zh_TW": "zh_TW",
     },
-    "dest" : "add__ons/digital__workplace/Public.properties",
+    "dest" : "add__ons/digital__workplace/Global.properties",
     "update_option" : "update_as_unapproved",
     "escape_special_characters": 0,
     "escape_quotes" : 0,

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/global_en.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/global_en.properties
@@ -1,0 +1,2 @@
+portal.global.newsDetail=News details
+portal.global.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ar.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ar.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_aro.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_aro.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_az.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_az.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ca.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ca.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ceb.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ceb.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_co.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_co.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_cs.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_cs.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_de.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_de.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=Neuigkeiten-Details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_el.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_el.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_en.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_en.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_es_ES.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_es_ES.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_eu.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_eu.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_fa.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_fa.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_fi.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_fi.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_fil.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_fil.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_fr.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_fr.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=D\u00e9tails de l'article
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_hi.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_hi.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_hu.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_hu.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_id.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_id.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_it.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_it.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ja.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ja.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ko.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ko.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_lt.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_lt.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ms.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ms.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_nl.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_nl.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_no.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_no.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_pcm.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_pcm.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_pl.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_pl.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_pt_BR.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_pt_BR.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_pt_PT.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_pt_PT.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ro.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ro.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ru.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ru.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_sk.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_sk.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_sl.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_sl.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_sq.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_sq.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=crwdns7100360:0crwdne7100360:0
-portal.public.oeditor=crwdns7100362:0crwdne7100362:0

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_sv_SE.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_sv_SE.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_th.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_th.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_tl.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_tl.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_tr.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_tr.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_uk.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_uk.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ur_IN.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_ur_IN.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_vi.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_vi.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_zh_CN.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_zh_CN.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_zh_TW.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_zh_TW.properties
@@ -1,2 +1,0 @@
-portal.public.newsDetail=News details
-portal.public.oeditor=OnlyOffice Editor

--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/global/navigation.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/global/navigation.xml
@@ -28,15 +28,15 @@
   <page-nodes>
     <node>
       <name>news-detail</name>
-      <label>#{portal.public.newsDetail}</label>
+      <label>#{portal.global.newsDetail}</label>
       <visibility>SYSTEM</visibility>
-      <page-reference>portal::public::newsDetail</page-reference>
+      <page-reference>portal::global::newsDetail</page-reference>
     </node>
     <node>
       <name>oeditor</name>
-      <label>#{portal.public.oeditor}</label>
+      <label>#{portal.global.oeditor}</label>
       <visibility>SYSTEM</visibility>
-      <page-reference>portal::public::oeditor</page-reference>
+      <page-reference>portal::global::oeditor</page-reference>
     </node>
   </page-nodes>
 </node-navigation>

--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/global/pages.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/global/pages.xml
@@ -20,6 +20,45 @@
   xsi:schemaLocation="http://www.exoplatform.org/xml/ns/gatein_objects_1_8 http://www.exoplatform.org/xml/ns/gatein_objects_1_8"
   xmlns="http://www.exoplatform.org/xml/ns/gatein_objects_1_8">
 
+  <page profiles="news">
+    <name>newsDetail</name>
+    <title>News detail</title>
+    <access-permissions>Everyone</access-permissions>
+    <edit-permission>*:/platform/administrators</edit-permission>
+    <container id="NewsDetailContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>news</application-ref>
+          <portlet-ref>NewsDetail</portlet-ref>
+        </portlet>
+        <title>News Detail</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+        <show-application-state>false</show-application-state>
+        <show-application-mode>false</show-application-mode>
+      </portlet-application>
+    </container>
+  </page>
+  <page profiles="onlyoffice">
+    <name>oeditor</name>
+    <title>Onlyoffice Editor Page</title>
+    <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
+    <edit-permission>manager:/platform/administrators</edit-permission>
+    <container id="OnlyofficeEditorPage" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>onlyoffice</application-ref>
+          <portlet-ref>OnlyofficeEditorPortlet</portlet-ref>
+        </portlet>
+        <title>Onlyoffice Editor</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+        <show-application-state>true</show-application-state>
+      </portlet-application>
+    </container>
+  </page>
   <page>
     <name>analytics</name>
     <title>Analytics</title>

--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/public/pages.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/public/pages.xml
@@ -23,43 +23,4 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_11 http://www.gatein.org/xml/ns/gatein_objects_1_11"
   xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_11">
-  <page profiles="news">
-    <name>newsDetail</name>
-    <title>News detail</title>
-    <access-permissions>Everyone</access-permissions>
-    <edit-permission>*:/platform/administrators</edit-permission>
-    <container id="NewsDetailContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-      <access-permissions>Everyone</access-permissions>
-      <portlet-application>
-        <portlet>
-          <application-ref>news</application-ref>
-          <portlet-ref>NewsDetail</portlet-ref>
-        </portlet>
-        <title>News Detail</title>
-        <access-permissions>Everyone</access-permissions>
-        <show-info-bar>false</show-info-bar>
-        <show-application-state>false</show-application-state>
-        <show-application-mode>false</show-application-mode>
-      </portlet-application>
-    </container>
-  </page>
-  <page profiles="onlyoffice">
-    <name>oeditor</name>
-    <title>Onlyoffice Editor Page</title>
-    <access-permissions>Everyone</access-permissions>
-    <edit-permission>manager:/platform/administrators</edit-permission>
-    <container id="OnlyofficeEditorPage" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-      <access-permissions>Everyone</access-permissions>
-      <portlet-application>
-        <portlet>
-          <application-ref>onlyoffice</application-ref>
-          <portlet-ref>OnlyofficeEditorPortlet</portlet-ref>
-        </portlet>
-        <title>Onlyoffice Editor</title>
-        <access-permissions>Everyone</access-permissions>
-        <show-info-bar>false</show-info-bar>
-        <show-application-state>true</show-application-state>
-      </portlet-application>
-    </container>
-  </page>
 </page-set>

--- a/translations.properties
+++ b/translations.properties
@@ -25,7 +25,7 @@ DW.properties=digital-workplace-webapps/src/main/resources/locale/navigation/por
 Intranet.properties=digital-workplace-webapps/src/main/resources/locale/navigation/portal/intranet_en.properties
 MyCraft.properties=digital-workplace-webapps/src/main/resources/locale/navigation/portal/mycraft_en.properties
 Administration.properties=digital-workplace-webapps/src/main/resources/locale/navigation/portal/administration_en.properties
-Public.properties=digital-workplace-webapps/src/main/resources/locale/navigation/portal/public_en.properties
+Global.properties=digital-workplace-webapps/src/main/resources/locale/navigation/portal/global_en.properties
 
 Webui.properties=digital-workplace-webapps/src/main/resources/locale/portal/webui_en.properties
 # Login


### PR DESCRIPTION
Prior to this change, each public site had to define its own news page detail in order to access to a news detail. This change moves the news detail page into global site to make the news detail page accessible from any site.