### PR TITLE
fix: Fix Administration Site Upgrade Plugin - MEED-6510 - Meeds-io/meeds#1921

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-upgrade-configuration.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-upgrade-configuration.xml
@@ -245,7 +245,7 @@
               <string>administration</string>
             </field>
             <field name="importMode">
-              <string>overwrite</string>
+              <string>merge</string>
             </field>
             <field name="pageNames">
               <collection type="java.util.ArrayList" item-type="java.lang.String">


### PR DESCRIPTION
Prior to this change, the upgrade plugin of Administration site for Sites Management page was using `importMode=overwrite` which deletes all pages of the site to reimport them. This changes changes the import mode to use '`merge`' instead in order to update the designated page name in the configured upgrade plugin without impacting other existing pages.