### PR TITLE
fix: Hide shared layout on OO Editor page - EXO-72989

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-upgrade-configuration.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-upgrade-configuration.xml
@@ -366,6 +366,53 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>OOEditorPageLayoutUpgrade3</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>150</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>overview.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/digital-workplace/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>oeditor</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
 </configuration>

--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/global/pages.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/global/pages.xml
@@ -25,8 +25,20 @@
     <title>Onlyoffice Editor Page</title>
     <access-permissions>Everyone</access-permissions>
     <edit-permission>manager:/platform/administrators</edit-permission>
+    <show-max-window>true</show-max-window>
+    <hide-shared-layout>true</hide-shared-layout>
     <container id="OnlyofficeEditorPage" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
       <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+         <portlet>
+           <application-ref>editors</application-ref>
+           <portlet-ref>EditorSupportPortlet</portlet-ref>
+         </portlet>
+         <title>EditorSupportPortlet</title>
+         <access-permissions>Everyone</access-permissions>
+         <show-info-bar>false</show-info-bar>
+         <show-application-state>true</show-application-state>
+       </portlet-application>
       <portlet-application>
         <portlet>
           <application-ref>onlyoffice</application-ref>


### PR DESCRIPTION
Before this fix, the OOEditor page display the shared layout few second before hidding it. We dont need it, and this commit add parameter hide-shared-layout