### PR TITLE
fix: when upgrading for 6.5 to 7.0, mycraft dashboard page is erased - EXO-76109

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-upgrade-configuration.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-upgrade-configuration.xml
@@ -344,7 +344,7 @@
               <boolean>true</boolean>
             </field>
             <field name="updateNavigation">
-              <boolean>true</boolean>
+              <boolean>false</boolean>
             </field>
             <field name="configPath">
               <string>war:/conf/sites/</string>


### PR DESCRIPTION
Before this fix, the upgrade plugin for page myteam update the portal navigation. This have effect to reload dashboard page, and override modifications done in UI in 6.5.5
This commit configure the UP to not update the navigation