### PR TITLE
fix: when upgrading for 6.5 to 7.0, mycraft dashboard page is erased - EXO-76109

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-upgrade-configuration.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-upgrade-configuration.xml
@@ -22,69 +22,6 @@
   <external-component-plugins>
     <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
     <component-plugin>
-      <name>ExoMyCraftSiteUpgrade</name>
-      <set-method>addUpgradePlugin</set-method>
-      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
-      <description>Updates MyCraft site display-order, page layouts and navigation</description>
-      <init-params>
-        <value-param>
-          <name>product.group.id</name>
-          <value>org.exoplatform.social</value>
-        </value-param>
-        <value-param>
-          <name>plugin.execution.order</name>
-          <value>120</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.execute.once</name>
-          <value>true</value>
-        </value-param>
-        <value-param>
-          <name>enabled</name>
-          <value>true</value>
-        </value-param>
-        <object-param>
-          <name>overview.upgrade</name>
-          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
-            <field name="updatePortalConfig">
-              <boolean>true</boolean>
-            </field>
-            <field name="updatePageLayout">
-              <boolean>true</boolean>
-            </field>
-            <field name="updateNavigation">
-              <boolean>true</boolean>
-            </field>
-            <field name="configPath">
-              <string>war:/conf/sites/</string>
-            </field>
-            <field name="portalType">
-              <string>portal</string>
-            </field>
-            <field name="portalName">
-              <string>mycraft</string>
-            </field>
-            <field name="pageNames">
-              <collection type="java.util.ArrayList" item-type="java.lang.String">
-                <value>
-                  <string>dashboard</string>
-                </value>
-                <value>
-                  <string>tasks</string>
-                </value>
-                <value>
-                  <string>achievements</string>
-                </value>
-                <value>
-                  <string>wallet</string>
-                </value>
-              </collection>
-            </field>
-          </object>
-        </object-param>
-      </init-params>
-    </component-plugin>
-    <component-plugin>
       <name>DwSiteUpgrade</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
@@ -344,7 +281,7 @@
               <boolean>true</boolean>
             </field>
             <field name="updateNavigation">
-              <boolean>true</boolean>
+              <boolean>false</boolean>
             </field>
             <field name="configPath">
               <string>war:/conf/sites/</string>


### PR DESCRIPTION
Before this fix, the upgrade plugin for page myteam update the portal navigation. This have effect to reload dashboard page, and override modifications done in UI in 6.5.5 This commit configure the UP to not update the navigation In addition, in some case, the UP ExoMyCraft can be launch in 7.0.x but it is not necessary, so this commit remove the cofniguration for this UP