### PR TITLE
feat: Configure Builtin Sites to be displayed in Sidebar By default - MEED-8323 - Meeds-io/MIPs#175

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/dw/portal.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/dw/portal.xml
@@ -4,6 +4,7 @@
         xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_10 http://www.gatein.org/xml/ns/gatein_objects_1_10"
         xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_10">
   <portal-name>dw</portal-name>
+  <displayed>true</displayed>
   <display-order>40</display-order>
   <locale>en</locale>
   <access-permissions>member:/platform/users;member:/platform/externals</access-permissions>
@@ -12,7 +13,11 @@
     <entry key="removable">false</entry>
     <entry key="icon">fa-dot-circle</entry>
   </properties>
-  <portal-layout>
-    <page-body> </page-body>
+  <portal-layout template="system:/groovy/portal/webui/container/UISiteLayout.gtmpl">
+    <site-middle-section>
+      <site-middle-center-section>
+        <page-body />
+      </site-middle-center-section>
+    </site-middle-section>
   </portal-layout>
 </portal-config>

--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/intranet/portal.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/intranet/portal.xml
@@ -23,6 +23,7 @@
   <portal-name>intranet</portal-name>
   <label>Intranet</label>
   <description>Develop your communication with a modern intranet</description>
+  <displayed>true</displayed>
   <display-order>1</display-order>
   <locale>en</locale>
   <access-permissions>member:/platform/users</access-permissions>
@@ -31,47 +32,11 @@
     <entry key="removable">false</entry>
     <entry key="icon">fa-home</entry>
   </properties>
-  <portal-layout>
-    <container id="UITopBarContainer" template="system:/groovy/portal/webui/container/UITopBarContainer.gtmpl">
-      <access-permissions>*:/platform/users</access-permissions>
-      <container id="left-topBar-container" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-        <access-permissions>Everyone</access-permissions>
-        <portlet-application>
-          <portlet>
-            <application-ref>social</application-ref>
-            <portlet-ref>TopBarLogo</portlet-ref>
-          </portlet>
-          <title>Company Logo</title>
-          <access-permissions>Everyone</access-permissions>
-          <show-info-bar>false</show-info-bar>
-          <show-application-state>false</show-application-state>
-        </portlet-application>
-        <portlet-application>
-          <portlet>
-            <application-ref>layout-management</application-ref>
-            <portlet-ref>SiteNavigation</portlet-ref>
-          </portlet>
-          <title>site navigation</title>
-          <access-permissions>Everyone</access-permissions>
-          <show-info-bar>false</show-info-bar>
-          <show-application-state>false</show-application-state>
-      </portlet-application>
-      </container>
-      <container id="middle-topBar-container" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-        <portlet-application>
-          <portlet>
-            <application-ref>social</application-ref>
-            <portlet-ref>TopBarMenu</portlet-ref>
-          </portlet>
-          <title>Top Bar Menu </title>
-          <access-permissions>Everyone</access-permissions>
-          <show-info-bar>false</show-info-bar>
-          <show-application-state>false</show-application-state>
-        </portlet-application>
-      </container>
-      <container id="right-topBar-container" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-      </container>
-    </container>
-    <page-body> </page-body>
+  <portal-layout template="system:/groovy/portal/webui/container/UISiteLayout.gtmpl">
+    <site-middle-section>
+      <site-middle-center-section>
+        <page-body />
+      </site-middle-center-section>
+    </site-middle-section>
   </portal-layout>
 </portal-config>

--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/sites/portal/contribute/portal.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/sites/portal/contribute/portal.xml
@@ -23,6 +23,7 @@
   <portal-name>contribute</portal-name>
   <label>#{portal.contribute.name}</label>
   <description>#{portal.contribute.description}</description>
+  <displayed>true</displayed>
   <display-order>10</display-order>
   <locale>en</locale>
   <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>

--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/sites/portal/mycraft/portal.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/sites/portal/mycraft/portal.xml
@@ -23,6 +23,7 @@
   <portal-name>mycraft</portal-name>
   <label>#{portal.mycraft.name}</label>
   <description>#{portal.mycraft.description}</description>
+  <displayed>true</displayed>
   <display-order>20</display-order>
   <locale>en</locale>
   <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>


### PR DESCRIPTION
This change will add an explicit definition of 'displayed' attribute in Default portal definitions in prder to import it in Sidebar by default. The default value of this flag has been changed to false in order to avoid errors while mapping DTO from database or when using the API to create a new Site.

In addition, this change will prepare the default sites layout to use the new Site Layout Definition.