### PR TITLE
fix: Edit dw site navigation displays dw as null - EXO-7700

### DIFF
--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/dw_en.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/dw_en.properties
@@ -16,7 +16,8 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 #
-portal.dw.home=Snapshot
+portal.dw.home=dw
+portal.dw.description=Digital Workplace
 portal.dw.externalHome=Home
 portal.dw.overview=Participate
 portal.dw.stream=Stream

--- a/digital-workplace-webapps/src/main/resources/locale/navigation/portal/intranet_en.properties
+++ b/digital-workplace-webapps/src/main/resources/locale/navigation/portal/intranet_en.properties
@@ -16,6 +16,8 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 #
+portal.intranet.name=Intranet
+portal.intranet.description=Develop your communication with a modern intranet
 portal.intranet.homepage=Home Page
 portal.intranet.news=News
 portal.intranet.section=Section

--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/dw/portal.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/dw/portal.xml
@@ -4,6 +4,8 @@
         xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_10 http://www.gatein.org/xml/ns/gatein_objects_1_10"
         xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_10">
   <portal-name>dw</portal-name>
+  <label>#{portal.dw.home}</label>
+  <description>#{portal.dw.description}</description>
   <displayed>true</displayed>
   <display-order>40</display-order>
   <locale>en</locale>

--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/intranet/portal.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal/intranet/portal.xml
@@ -21,8 +21,8 @@
   xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_10 http://www.gatein.org/xml/ns/gatein_objects_1_10"
   xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_10">
   <portal-name>intranet</portal-name>
-  <label>Intranet</label>
-  <description>Develop your communication with a modern intranet</description>
+  <label>#{portal.intranet.name}</label>
+  <description>#{portal.intranet.description}</description>
   <displayed>true</displayed>
   <display-order>1</display-order>
   <locale>en</locale>


### PR DESCRIPTION
prior to this fix, editing any dw page site navigation displays site name as null instead of dw.
This fix adds missing label and description keys on dw configuration and updates intranet configuration by allowing its label & descriptions to have values depending on user language preference