### PR TITLE
fix: make insermode=conserve for sites dw, myworkspace, and space_templates - EXO-78643

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-configuration.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-configuration.xml
@@ -25,7 +25,7 @@
               <boolean>${exo.dw.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${exo.dw.portalConfig.metadata.importmode:insert}</string>
+              <string>${exo.dw.portalConfig.metadata.importmode:conserve}</string>
             </field>
             <field name="predefinedOwner">
               <collection type="java.util.HashSet">
@@ -65,7 +65,7 @@
               <boolean>${exo.myworkspace.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${exo.myworkspace.portalConfig.metadata.importmode:insert}</string>
+              <string>${exo.myworkspace.portalConfig.metadata.importmode:conserve}</string>
             </field>
             <field name="templateLocation">
               <string>war:/conf/digital-workplace/</string>
@@ -181,7 +181,7 @@
               <boolean>${exo.spaceTemplates.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${exo.spaceTemplates.portalConfig.metadata.importmode:insert}</string>
+              <string>${exo.spaceTemplates.portalConfig.metadata.importmode:conserve}</string>
             </field>
           </object>
         </object-param>


### PR DESCRIPTION
Before this fix, when removing a page in the navigation of site dw, or myworkspace or in space template, the page is recreated at startup To prevent this, we change the default configuration for importMode to use "conserve", so that removed page is not recreated.