### PR TITLE
ix: Fix email-connector admin page display after upgrade 7.1.x/7.2.x - EXO-87520

### DIFF
--- a/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-upgrade-configuration.xml
+++ b/digital-workplace-webapps/src/main/webapp/WEB-INF/conf/digital-workplace/portal-upgrade-configuration.xml
@@ -452,6 +452,56 @@
         </object-param>
       </init-params>
     </component-plugin>
+	<component-plugin>
+      <name>EmailAdminUpgrade-7.2</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>120</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>overview.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/digital-workplace/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>administration</string>
+            </field>
+            <field name="importMode">
+              <string>merge</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>email-connector</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
 </configuration>


### PR DESCRIPTION
Prior to this change, when upgrading from 7.1.x to 7.2.x, the email-connector admin page is displayed empty without the EmailConnectorAdministration portlet inside caused by the email-connector admin navigation node already existing into 7.1.x without any related page. After this commit, we ensure to update the email-connector admin page configuration using the EmailAdminUpgrade-7.2 upgrade plugin.